### PR TITLE
Use metadata.packageName when grouping deprecations with same call stack

### DIFF
--- a/spec/grim-spec.coffee
+++ b/spec/grim-spec.coffee
@@ -102,6 +102,18 @@ describe "Grim", ->
       expect(deprecation.getStacks()[0].metadata).toEqual {foo: "bar"}
       expect(deprecation.getStacks()[1].metadata).toEqual {baz: "quux"}
 
+    describe "when a packageName is defined", ->
+      it "uses the packageName when grouping deprecations with the same call stack", ->
+        deprecatedFn = (metadata) -> grim.deprecate("It's deprecated.", metadata)
+
+        deprecatedFn(packageName: "bar")
+        deprecatedFn(packageName: "quux")
+
+        expect(grim.getDeprecations().length).toBe 2
+        [deprecation1, deprecation2] = grim.getDeprecations()
+        expect(deprecation1.getStacks()[0].metadata).toEqual {packageName: "bar"}
+        expect(deprecation2.getStacks()[0].metadata).toEqual {packageName: "quux"}
+
   it "converts locations in .coffee files using source maps", ->
     require './fixtures/deprecation.coffee'
     expect(grim.getDeprecations().length).toBe(1)

--- a/spec/grim-spec.coffee
+++ b/spec/grim-spec.coffee
@@ -107,11 +107,23 @@ describe "Grim", ->
         deprecatedFn = (metadata) -> grim.deprecate("It's deprecated.", metadata)
 
         deprecatedFn(packageName: "bar")
+        deprecatedFn(packageName: "bar")
+        deprecatedFn(packageName: "quux")
         deprecatedFn(packageName: "quux")
 
         expect(grim.getDeprecations().length).toBe 2
         [deprecation1, deprecation2] = grim.getDeprecations()
+        expect(deprecation1.callCount).toBe 2
         expect(deprecation1.getStacks()[0].metadata).toEqual {packageName: "bar"}
+        expect(deprecation2.callCount).toBe 2
+        expect(deprecation2.getStacks()[0].metadata).toEqual {packageName: "quux"}
+
+        grim.addSerializedDeprecation(deprecation1.serialize())
+        expect(grim.getDeprecationsLength()).toBe 2
+        [deprecation1, deprecation2] = grim.getDeprecations()
+        expect(deprecation1.callCount).toBe 4
+        expect(deprecation1.getStacks()[0].metadata).toEqual {packageName: "bar"}
+        expect(deprecation2.callCount).toBe 2
         expect(deprecation2.getStacks()[0].metadata).toEqual {packageName: "quux"}
 
   it "converts locations in .coffee files using source maps", ->

--- a/src/grim.coffee
+++ b/src/grim.coffee
@@ -66,7 +66,7 @@ unless global.__grim__?
       message = deprecation.getMessage()
       {fileName, lineNumber} = deprecation
       stacks = deprecation.getStacks()
-      packageName = metadata?.packageName ? ""
+      packageName = stacks[0]?.metadata?.packageName ? ""
 
       grim.deprecations[fileName] ?= {}
       grim.deprecations[fileName][lineNumber] ?= {}

--- a/src/grim.coffee
+++ b/src/grim.coffee
@@ -10,8 +10,9 @@ unless global.__grim__?
     getDeprecations: ->
       deprecations = []
       for fileName, deprecationsByLineNumber of grim.deprecations
-        for lineNumber, deprecation of deprecationsByLineNumber
-          deprecations.push(deprecation)
+        for lineNumber, deprecationsByPackage of deprecationsByLineNumber
+          for packageName, deprecation of deprecationsByPackage
+            deprecations.push(deprecation)
       deprecations
 
     getDeprecationsLength: ->
@@ -48,9 +49,12 @@ unless global.__grim__?
       deprecationSite = stack[0]
       fileName = deprecationSite.getFileName()
       lineNumber = deprecationSite.getLineNumber()
+      packageName = metadata?.packageName ? ""
       grim.deprecations[fileName] ?= {}
-      grim.deprecations[fileName][lineNumber] ?= new Deprecation(message)
-      deprecation = grim.deprecations[fileName][lineNumber]
+      grim.deprecations[fileName][lineNumber] ?= {}
+      grim.deprecations[fileName][lineNumber][packageName] ?= new Deprecation(message)
+
+      deprecation = grim.deprecations[fileName][lineNumber][packageName]
 
       # Add the current stack trace to the deprecation
       deprecation.addStack(stack, metadata)
@@ -62,10 +66,13 @@ unless global.__grim__?
       message = deprecation.getMessage()
       {fileName, lineNumber} = deprecation
       stacks = deprecation.getStacks()
+      packageName = metadata?.packageName ? ""
 
       grim.deprecations[fileName] ?= {}
-      grim.deprecations[fileName][lineNumber] ?= new Deprecation(message, fileName, lineNumber)
-      deprecation = grim.deprecations[fileName][lineNumber]
+      grim.deprecations[fileName][lineNumber] ?= {}
+      grim.deprecations[fileName][lineNumber][packageName] ?= new Deprecation(message, fileName, lineNumber)
+
+      deprecation = grim.deprecations[fileName][lineNumber][packageName]
       deprecation.addStack(stack, stack.metadata) for stack in stacks
       grim.emit("updated", deprecation)
       return


### PR DESCRIPTION
This closes https://github.com/atom/grim/issues/6. 

* 83095d4 adds a failing test to demonstrate the problem with grouping deprecations with different `metadata.packageNames`
* 6a58ef7 fixes the problem by using the `metadata.packageName` as another level of grouping when processing deprecations with the same call stack.

The test added in 83095d4, before 6a58ef7 is applied:

```
Running "shell:test" (shell) task
.......F....

Grim
  when metadata is provided as a second argument
    when a packageName is defined
      it uses the packageName when grouping deprecations with the same call stack
        Expected 1 to be 2. (spec/grim-spec.coffee:112:47)
        TypeError: Cannot call method 'getStacks' of undefined (spec/grim-spec.coffee:115:29)


Finished in 0.785 seconds
12 tests, 78 assertions, 2 failures, 0 skipped
```

The test added in 83095d4, after 6a58ef7 is applied:

```
Running "shell:test" (shell) task
............

Finished in 0.858 seconds
12 tests, 78 assertions, 0 failures, 0 skipped
```

cc @nathansobo @kevinsawicki for :thought_balloon:  -- maybe there's a cleaner way to do this?