### PR TITLE
Drop Emissary

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "dependencies": {
-    "emissary": "^1.2.0"
+    "event-kit": "^1.4.1"
   },
   "devDependencies": {
     "coffee-script": "^1.7.0",

--- a/src/grim.coffee
+++ b/src/grim.coffee
@@ -1,10 +1,10 @@
-{Emitter} = require 'emissary'
 Deprecation = require './deprecation'
 
 unless global.__grim__?
+  {Emitter} = require 'event-kit'
   grim = global.__grim__ =
     deprecations: {}
-
+    emitter: new Emitter
     includeDeprecatedAPIs: true
 
     getDeprecations: ->
@@ -56,7 +56,7 @@ unless global.__grim__?
 
       # Add the current stack trace to the deprecation
       deprecation.addStack(stack, metadata)
-      grim.emit("updated", deprecation)
+      @emitter.emit("updated", deprecation)
       return
 
     addSerializedDeprecation: (serializedDeprecation) ->
@@ -72,10 +72,10 @@ unless global.__grim__?
 
       deprecation = grim.deprecations[fileName][lineNumber][packageName]
       deprecation.addStack(stack, stack.metadata) for stack in stacks
-      grim.emit("updated", deprecation)
+      @emitter.emit("updated", deprecation)
       return
 
-  Emitter.extend(grim)
+    on: (eventName, callback) -> @emitter.on(eventName, callback)
 
 getRawStack = (error) ->
   originalPrepareStackTrace = Error.prepareStackTrace


### PR DESCRIPTION
Aside from being deprecated in favor of `event-kit`, this dependency added `12ms` to startup time.

/cc: @nathansobo