### PR TITLE
return unknown location if stack is less than 2

### DIFF
--- a/spec/grim-spec.coffee
+++ b/spec/grim-spec.coffee
@@ -64,6 +64,17 @@ describe "Grim", ->
       expect(deprecation.getCallCount()).toBe 1
       expect(deprecation.getStacks().length).toBe 1
 
+    it "async callsite", (done) ->
+      suchFunction = -> grim.deprecate("Use soWow instead.")
+      setTimeout( ->
+        suchFunction()
+
+        deprecation = grim.getDeprecations()[0]
+        expect(deprecation.getLocationFromCallsite()).toBe 'unknown'
+
+        done()
+      , 0)
+
   describe "when a deprecated function is called more than once", ->
     it "increments the count and appends the new stack trace", ->
       suchFunction = -> grim.deprecate("Use soWow instead.")

--- a/src/deprecation.coffee
+++ b/src/deprecation.coffee
@@ -29,6 +29,7 @@ class Deprecation
         "#{callsite.getTypeName()}.#{callsite.getMethodName() ? callsite.getFunctionName() ? '<anonymous>'}"
 
   getLocationFromCallsite: (callsite) ->
+    return "unknown" unless callsite?
     return callsite.location if callsite.location?
 
     if callsite.isNative()


### PR DESCRIPTION
If .deprecate() is called in an async function the callsite stack will only have a length of 1