### PR TITLE
Fix failing Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
+node_js: '8'
 
 notifications:
   email: false
-
-node_js:
-  - 0.10
 
 git:
   depth: 10


### PR DESCRIPTION
The Travis CI build recently started failing with the [following error](https://travis-ci.org/atom/grim/builds/569445189#L304-L310):

```
/home/travis/build/atom/grim/node_modules/jasmine-focused/node_modules/jasmine-node/node_modules/coffeestack/node_modules/fs-plus/lib/fs-plus.js:730
  module.exports = new Proxy({}, {
                       ^
ReferenceError: Proxy is not defined
    at Object.<anonymous> (/home/travis/build/atom/grim/node_modules/jasmine-focused/node_modules/jasmine-node/node_modules/coffeestack/node_modules/fs-plus/lib/fs-plus.js:730:24)
    at Object.<anonymous> (/home/travis/build/atom/grim/node_modules/jasmine-focused/node_modules/jasmine-node/node_modules/coffeestack/node_modules/fs-plus/lib/fs-plus.js:740:4)
    at Module._compile (module.js:456:26)
```

This pull request updates the Travis CI config to use Atom's current version of Node (Node 8), which will hopefully resolve this issue. 🤞