### PR TITLE
Update Travis CI to use Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: '8'
+node_js: '10'
 
 notifications:
   email: false


### PR DESCRIPTION
https://github.com/atom/grim/pull/17 updating Travis CI to use Node 8. In https://github.com/atom/grim/pull/17#issuecomment-519711810, @Aerijo kindly pointed out that the current stable version of Atom is running on Node 10: 

```
$ atom --version
Atom    : 1.39.1
Electron: 3.1.10
Chrome  : 66.0.3359.181
Node    : 10.2.0
```

So, this pull request updates our Travis CI config to use Node 10.