### PR TITLE
Fix TypeError: Cannot read property 'emit' of undefined

### DIFF
--- a/src/grim.coffee
+++ b/src/grim.coffee
@@ -56,7 +56,7 @@ unless global.__grim__?
 
       # Add the current stack trace to the deprecation
       deprecation.addStack(stack, metadata)
-      @emitter.emit("updated", deprecation)
+      grim.emitter.emit("updated", deprecation)
       return
 
     addSerializedDeprecation: (serializedDeprecation) ->
@@ -72,10 +72,10 @@ unless global.__grim__?
 
       deprecation = grim.deprecations[fileName][lineNumber][packageName]
       deprecation.addStack(stack, stack.metadata) for stack in stacks
-      @emitter.emit("updated", deprecation)
+      grim.emitter.emit("updated", deprecation)
       return
 
-    on: (eventName, callback) -> @emitter.on(eventName, callback)
+    on: (eventName, callback) -> grim.emitter.on(eventName, callback)
 
 getRawStack = (error) ->
   originalPrepareStackTrace = Error.prepareStackTrace


### PR DESCRIPTION
Use `emitter` set on `grim` variable. Fixes the below error.
```
TypeError: Cannot read property 'emit' of undefined
    at deprecate (/home/runner/CreativeThistleWebmaster/node_modules/grim/lib/grim.js:72:22)
    at someFunction (/home/runner/CreativeThistleWebmaster/index.js:4:3)
    at /home/runner/CreativeThistleWebmaster/index.js:7:1
    at Script.runInContext (vm.js:130:18)
    at Object.<anonymous> (/run_dir/interp.js:209:20)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```
